### PR TITLE
fix rollover fee calculation to entire order

### DIFF
--- a/src/kraken-fees-calculator.js
+++ b/src/kraken-fees-calculator.js
@@ -77,7 +77,7 @@ class KrakenFeesCalculator {
       }
       return {
         opening: (options.trade.amount * options.trade.price_in * margin_opening_fees / 100),
-        rollover: ((1-(1/options.trade.leverage)) * options.trade.amount * options.trade.price_in * margin_rollover_fees / 100 * Math.ceil(duration/4)),
+        rollover: (options.trade.amount * options.trade.price_in * margin_rollover_fees / 100 * Math.ceil(duration/4)),
         leverage: options.trade.leverage
       }
     };


### PR DESCRIPTION
In reference to issue: Rollover calculation doubt #5
https://github.com/kraken-fees-calculator/kraken-fees-calculator.github.io/issues/5

This is my first venture in the Github process so I hope I am doing this the way it should. Fingers crossed.
Also, I am completely agnostic about this language (don't know what it is), so syntax problems may have been introduced. But I figured removing a factor in the calculation wouldn't cause trouble.